### PR TITLE
usbdl: throw an error if not handshaked

### DIFF
--- a/SoC/common/usbdl.py
+++ b/SoC/common/usbdl.py
@@ -37,6 +37,9 @@ class ProtocolError(Exception):
 class SocNotRecognizedError(Exception):
     pass
 
+class NotHandshakedError(Exception):
+    pass
+
 class UsbDl:
     commands = {
         'CMD_C8': 0xC8, # Don't know the meaning of this yet.
@@ -194,6 +197,8 @@ class UsbDl:
             echo_data = self.ser.read(len(data))
             if self.debug:
                 print("<- {}".format(binascii.b2a_hex(echo_data)))
+            if echo_data[0] == data[0]+0x1:
+                raise NotHandshakedError
             if echo_data != data:
                 raise EchoBytesMismatchException
 


### PR DESCRIPTION
If we are not handshaked the BROM just echoes everything back adding 1. In that case throw a more descriptive error.